### PR TITLE
fix: pyaudio input overflow

### DIFF
--- a/backend/RecordThread.py
+++ b/backend/RecordThread.py
@@ -58,7 +58,7 @@ class RecordThread(threading.Thread):
         silent_samples = 0
 
         while self.record:
-            self.chunk_data = audio_stream.read(self.chunkSize)
+            self.chunk_data = audio_stream.read(self.chunkSize, exception_on_overflow=False)
             self.chunk_rms = audioop.rms(self.chunk_data, 2)
             self.frames += bytearray(self.chunk_data)
             # print(f'talking_samples:{talking_samples}, silent_samples:{silent_samples}')


### PR DESCRIPTION
This should fix the input overflow caused by the recording thread starting early. It should work but isn't optimal. I cannot test the audio recording on linux, so I can't verify if the audio is working.